### PR TITLE
Add test case and simple workaround for Is and As corner cases

### DIFF
--- a/prettifier.go
+++ b/prettifier.go
@@ -111,6 +111,10 @@ func (p *prettifier) peek() rune {
 }
 
 func (p *prettifier) inInitialism() bool {
+	// deal with Is and As corner cases
+	if p.input[p.start+1] == 's' {
+		return false
+	}
 	for _, r := range p.input[p.start:p.pos] {
 		if unicode.IsLower(r) && r != 's' {
 			return false

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -224,4 +224,9 @@ var Cases = []struct {
 		input: "TestFooReturnsIDsAValue",
 		want:  "Foo returns IDs a value",
 	},
+	{
+		name:  "does not treat 'Is' or 'As' as initialisms",
+		input: "TestThisIsAsItShouldBe",
+		want:  "This is as it should be",
+	},
 }


### PR DESCRIPTION
In the PR https://github.com/bitfield/gotestdox/pull/9, I've introduced a bug in the logic where the inputs `IsAs` or `AsIs` are considered `one initialism IsAs or AsIs` while it should be considered separated words `Is and As` or `As and Is`.