### PR TITLE
Added a verbose flag which makes gotestdox print the output of tests.

### DIFF
--- a/gotestdox_test.go
+++ b/gotestdox_test.go
@@ -48,6 +48,7 @@ func TestParseJSON_ReturnsValidDataForValidJSON(t *testing.T) {
 
 func TestParseJSON_ErrorsOnInvalidJSON(t *testing.T) {
 	t.Parallel()
+	t.Log("lala")
 	input := `invalid`
 	_, err := gotestdox.ParseJSON(input)
 	if err == nil {
@@ -70,7 +71,7 @@ func TestEventString_FormatsPassAndFailEventsDifferently(t *testing.T) {
 	}
 }
 
-func TestRelevantIsTrueForTestPassOrFailEvents(t *testing.T) {
+func TestIsFinishedTestIsTrueForTestPassOrFailEvents(t *testing.T) {
 	t.Parallel()
 	tcs := []gotestdox.Event{
 		{
@@ -83,14 +84,14 @@ func TestRelevantIsTrueForTestPassOrFailEvents(t *testing.T) {
 		},
 	}
 	for _, event := range tcs {
-		relevant := event.Relevant()
+		relevant := event.IsFinishedTest()
 		if !relevant {
 			t.Errorf("false for relevant event %q on %q", event.Action, event.Test)
 		}
 	}
 }
 
-func TestRelevantIsFalseForNonTestPassFailEvents(t *testing.T) {
+func TestIsFinishedTestIsFalseForNonTestPassFailEvents(t *testing.T) {
 	t.Parallel()
 	tcs := []gotestdox.Event{
 		{
@@ -115,7 +116,7 @@ func TestRelevantIsFalseForNonTestPassFailEvents(t *testing.T) {
 		},
 	}
 	for _, event := range tcs {
-		relevant := event.Relevant()
+		relevant := event.IsFinishedTest()
 		if relevant {
 			t.Errorf("true for irrelevant event %q on %q", event.Action, event.Test)
 		}
@@ -184,7 +185,7 @@ func TestExecGoTest_SetsOKToFalseWhenCommandErrors(t *testing.T) {
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 	}
-	td.ExecGoTest([]string{"bogus"})
+	td.ExecGoTest([]string{"bogus"}, false)
 	if td.OK {
 		t.Error("want not ok")
 	}
@@ -196,7 +197,7 @@ func ExampleTestDoxer_Filter() {
 	td := gotestdox.NewTestDoxer()
 	td.Stdin = strings.NewReader(input)
 	color.NoColor = true
-	td.Filter()
+	td.Filter(false)
 	// Output:
 	// demo:
 	//  ✔ It works (0.00s)
@@ -213,33 +214,33 @@ func ExampleEvent_String() {
 	// ✔ It works (0.00s)
 }
 
-func ExampleEvent_Relevant_true() {
+func ExampleEvent_IsFinishedTest_true() {
 	event := gotestdox.Event{
 		Action: "pass",
 		Test:   "TestItWorks",
 	}
-	fmt.Println(event.Relevant())
+	fmt.Println(event.IsFinishedTest())
 	// Output:
 	// true
 }
 
-func ExampleEvent_Relevant_false() {
+func ExampleEvent_IsFinishedTest_false() {
 	event := gotestdox.Event{
 		Action: "fail",
 		Test:   "ExampleIsIrrelevant",
 	}
-	fmt.Println(event.Relevant())
+	fmt.Println(event.IsFinishedTest())
 	// Output:
 	// false
 }
 
 func ExampleParseJSON() {
-	input := `{"Action":"pass","Package":"demo","Test":"TestItWorks","Elapsed":0.2}`
+	input := `{"Action":"pass","Package":"demo","Test":"TestItWorks","Output":"test","Elapsed":0.2}`
 	event, err := gotestdox.ParseJSON(input)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("%#v\n", event)
 	// Output:
-	// gotestdox.Event{Action:"pass", Package:"demo", Test:"TestItWorks", Sentence:"", Elapsed:0.2}
+	// gotestdox.Event{Action:"pass", Package:"demo", Test:"TestItWorks", Sentence:"", Output:"test", Elapsed:0.2}
 }

--- a/testdata/script/test_does_not_produce_text_output_without_verbose_flag.txtar
+++ b/testdata/script/test_does_not_produce_text_output_without_verbose_flag.txtar
@@ -1,0 +1,17 @@
+stdin input.json
+exec gotestdox
+cmp stdout golden.txt
+
+-- input.json --
+{"Action":"run","Package":"dummy","Test":"TestDummy"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"=== RUN   TestDummy\n"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"    file_test.go:75: hello"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"--- PASS: TestDummy (0.00s)\n"}
+{"Action":"pass","Package":"dummy","Test":"TestDummy"}
+{"Action":"output","Package":"dummy","Output":"PASS\n"}
+{"Action":"output","Package":"dummy","Output":"ok  \tdummy\t0.180s\n"}
+{"Action":"pass","Package":"dummy","Elapsed":0.18}
+-- golden.txt --
+dummy:
+ ✔ Dummy (0.00s)
+

--- a/testdata/script/test_produces_text_output_with_verbose_flag.txtar
+++ b/testdata/script/test_produces_text_output_with_verbose_flag.txtar
@@ -1,0 +1,20 @@
+stdin input.json
+exec gotestdox -v
+cmp stdout golden.txt
+
+-- input.json --
+{"Action":"run","Package":"dummy","Test":"TestDummy"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"=== RUN   TestDummy\n"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"    file_test.go:75: hello"}
+{"Action":"output","Package":"dummy","Test":"TestDummy","Output":"--- PASS: TestDummy (0.00s)\n"}
+{"Action":"pass","Package":"dummy","Test":"TestDummy"}
+{"Action":"output","Package":"dummy","Output":"PASS\n"}
+{"Action":"output","Package":"dummy","Output":"ok  \tdummy\t0.180s\n"}
+{"Action":"pass","Package":"dummy","Elapsed":0.18}
+-- golden.txt --
+dummy:
+ ✔ Dummy (0.00s)
+     Output:
+       file_test.go:75:
+         hello
+


### PR DESCRIPTION
Just recently found this little gem, really makes it way more fun to code and easier to to make focused test cases.

One issue I had though is that I usually only develop with tests and the outputs from the code and tests weren't displaying when running the tests. Which is essential when you hit a snag and want to debug. One alternative is to just go back to the good ol' `go test` tool without `gotestdox`, but that isn't as easy and pretty to parse at a glance and hides the test name in that TestCamelCase.

So I added a `-v` flag that behaves similarly to `go test -v`.

I like feedback in any form so go ham if you'd like, lived on the internet for too long to get offended, even if you don't like the concept to begin with. 